### PR TITLE
fix: scroll back to `state.from`

### DIFF
--- a/scrollimation.js
+++ b/scrollimation.js
@@ -41,7 +41,10 @@ class ScrollimationWorker {
 		if (scrollPosition >= state.from && !state.startEmitted) {
 			state.startEmitted = true
 			state.start(state)
-		} else if (scrollPosition <= state.from) state.startEmitted = false
+		} else if (scrollPosition <= state.from && state.startEmitted) {
+			state.startEmitted = false
+			state.start(state)
+		}
 
 		if (scrollPosition >= state.to && !state.endEmitted) {
 			state.endEmitted = true


### PR DESCRIPTION
Hi, 
I'm doing some scroll-based animation and found your library very useful. Thanks a lot.

However, I found some problems. When scrolling across `state.from` or `state.to` , the target properties might remain a value that is very close to the given `from` or `to` value. 

On precision devices like MacBook, this problem does not exist (or nearly), but when scrolling with a typical mouse, which might scroll 3 lines at one wheel click, this issue can be really problematic. 
 **Especially when target property is opacity which animates from 1 to 0.** You'll see a near-transparent visible thing remains on the page, which should go away as we expected.

I can overcome this by utilizing your `end` function like what your example has described: 

https://github.com/ArtRinor/Scrollimation/blob/9539bb319b6e5795bbcd0170dde6d846bfcaa6bf/README.md#L258-L268

...But **this only works when I want this target to fade out**. `start` function won't work for me when targets are fade while visitors try to scroll back.  So you'll not find any problem when scrolling down, but when you accidentally scrolling back, glitches might appear.

According to your README, 

https://github.com/ArtRinor/Scrollimation/blob/9539bb319b6e5795bbcd0170dde6d846bfcaa6bf/README.md#L233

Whether this position is reached when scrolling forward, or backward. So I'm starting this pull request, and make `animate` method trigger `state.start(state)` while changing `state.startEmitted` back to false.

This work on my case.

But I have no idea what users are doing with `start` function, and whether this change is done properly. If they're just giving initial values, then this would be totally fine. But if they're preparing elements (doing some DOM operation for example), then `start` function shouldn't be call twice. 

Or, I would better create another function (like `state.back` ) in parallel and leave `state.start` as it is. Is this better?

I don't know which one make sense to you.  **Please reply or just close this PR if my change is not proper. I don't want to mess up.**

Thanks and merry chirstmas!

